### PR TITLE
Remove redundant call to openFile.

### DIFF
--- a/catch-mask2.hs
+++ b/catch-mask2.hs
@@ -15,7 +15,6 @@ main = do
           Left e | isDoesNotExistError e -> loop n fs
                  | otherwise             -> throwIO e
           Right h -> do
-            h <- openFile f ReadMode
             s <- hGetContents h
             loop (n + length (lines s)) fs
 


### PR DESCRIPTION
Actually, why not just use readFile, both here and in catch-mask.hs?
