### PR TITLE
fwaccel: fix not in scope error

### DIFF
--- a/fwaccel.hs
+++ b/fwaccel.hs
@@ -41,8 +41,8 @@ step k g = generate (shape g) sp                           -- <1>
    sp ix = let
              (Z :. i :. j) = unlift ix                     -- <3>
            in
-             A.min (g ! (index2 i j))                      -- <4>
-                   (g ! (index2 i k') + g ! (index2 k' j))
+             min (g ! (index2 i j))                        -- <4>
+                 (g ! (index2 i k') + g ! (index2 k' j))
 -- >>
 
 -- -----------------------------------------------------------------------------


### PR DESCRIPTION
Data.Array.Accelerate has no min function, and it does not export the
min function from Prelude.
