### PR TITLE
Compile rpar program with -threaded

### DIFF
--- a/parconc-examples.cabal
+++ b/parconc-examples.cabal
@@ -87,6 +87,7 @@ executable rpar
   build-depends:   base >= 4.5 && < 4.9
                  , time >= 1.4 && < 1.6
                  , parallel ==3.2.*
+  ghc-options: -threaded
   default-language: Haskell2010
 
 executable sudoku1


### PR DESCRIPTION
Per <http://chimera.labs.oreilly.com/books/1230000000929/ch02.html#sec_par-rpar-rseq>, this program
is meant to be compiled with the threaded runtime.