### PR TITLE
Fix ping-fail add missing build depends

### DIFF
--- a/parconc-examples.cabal
+++ b/parconc-examples.cabal
@@ -926,6 +926,7 @@ executable ping-tc-notify
 
 executable ping-fail
   main-is: distrib-ping/ping-fail.hs
+  other-modules: DistribUtils
   build-depends:   base >= 4.5 && < 4.9
                  , binary >=0.6.3 && < 0.8
                  , template-haskell >= 2.7 && < 2.11


### PR DESCRIPTION
In my case `stack build` fails with exception:
```
Warning: The following modules should be added to exposed-modules or other-modules in .../parconc-examples/parconc-examples.cabal:
    - In ping-fail component:
        DistribUtils

Missing modules in the cabal file are likely to cause undefined reference errors from the linker, along with other problems.
parconc-examples-0.4.5: copy/register
Installing executable(s) in
```
This PR should fix the issue