### PR TITLE
add explicit build tool deps

### DIFF
--- a/parconc-examples.cabal
+++ b/parconc-examples.cabal
@@ -318,6 +318,8 @@ executable  parinfer
                  , deepseq >= 1.3 && < 1.5
                  , monad-par >= 0.3.4 && < 0.4
                  , array >= 0.4 && <0.6
+  build-tools:     alex
+                 , happy
   default-language: Haskell2010
 
 -- -----------------------------------------------------------------------------


### PR DESCRIPTION
added alex and happy to parinfer cabal entry, omitting this can cause build failures on systems without a global alex+happy

arises most generally on systems using stack to manage ghc toolchain entirely