### PR TITLE
Fix misuses of maxY and minX in kmeans/GenSamples.hs.

### DIFF
--- a/kmeans/GenSamples.hs
+++ b/kmeans/GenSamples.hs
@@ -16,6 +16,7 @@ maxY = 10
 minSD = 1.5
 maxSD = 2.0
 
+main :: IO ()
 main = do
     n: minp: maxp: rest <- fmap (fmap read) getArgs
 
@@ -24,8 +25,8 @@ main = do
         _ -> return ()
 
     nps <- replicateM n (randomRIO (minp, maxp))
-    xs  <- replicateM n (randomRIO (minX, maxY))
-    ys  <- replicateM n (randomRIO (minX, maxY))
+    xs  <- replicateM n (randomRIO (minX, maxX))
+    ys  <- replicateM n (randomRIO (minY, maxY))
     sds <- replicateM n (randomRIO (minSD, maxSD))
 
     let params = zip5 nps xs ys sds sds
@@ -66,7 +67,6 @@ generate2DSamples :: Int                 -- number of samples to generate
                   -> Double -> Double    -- X and Y of the mean
                   -> Double -> Double    -- X and Y standard deviations
                   -> IO [Point]
-
 generate2DSamples n mx my sdx sdy = do
   gen <- newStdGen
   let (genx, geny) = split gen


### PR DESCRIPTION
In `kmeans/GenSamples.hs`, it seems that `maxY` was being used instead of `maxX`, and `minX` was being used instead of `minY`.

Since `maxX == maxY` and `minX == minY` in the current code, this hasn't actually caused any problems.  However, I think it would make more sense for people reading `GenSamples.hs` if `maxX` and `minY` were used (correctly).

This PR also fixes up a few other small things (type signature for `main` and removal of empty line).