### PR TITLE
Update parconc-examples.cabal: base and template-haskell versions

### DIFF
--- a/parconc-examples.cabal
+++ b/parconc-examples.cabal
@@ -84,7 +84,7 @@ common deps
   build-depends:
      array >= 0.4 && <0.6,
      async >= 2.0 && < 2.3,
-     base >= 4.5 && < 4.14,
+     base >= 4.5 && < 4.15,
      binary >=0.6.3 && < 0.11,
      bytestring >= 0.9 && < 0.12,
      containers >= 0.4 && < 0.6,
@@ -98,7 +98,7 @@ common deps
      random >= 1.0 && < 1.3,
      stm >=2.4 && < 2.6,
      time >= 1.4 && < 1.12,
-     template-haskell >= 2.7 && < 2.16,
+     template-haskell >= 2.7 && < 2.17,
      transformers >=0.3 && <0.6,
      utf8-string >= 0.3 && < 1.1,
      vector >= 0.10 && < 0.13,


### PR DESCRIPTION
Lifted 'base' and 'template-haskell' versioning limit because the current ones were impeding a successful cabal/stack build.





