### PR TITLE
Build `parinfer` with `-threaded`

### DIFF
--- a/parconc-examples.cabal
+++ b/parconc-examples.cabal
@@ -265,6 +265,7 @@ executable  parinfer
   import: deps
   main-is: parinfer.hs
   hs-source-dirs: parinfer
+  ghc-options: -threaded
   other-modules:  InferMonad
                   Term
                   FiniteMap


### PR DESCRIPTION
Issue: https://github.com/simonmar/parconc-examples/issues/33
Enable "Parallel Type Inferencer" examples in chapter 4 to be run when built with `stack` or `cabal`.