### PR TITLE
Adding shell.nix

### DIFF
--- a/shell.nix
+++ b/shell.nix
@@ -1,0 +1,21 @@
+let 
+  nixpkgs = import (builtins.fetchTarball {
+            url = "https://github.com/NixOS/nixpkgs/archive/5c79b3dda06744a55869cae2cba6873fbbd64394.tar.gz";}) {}; 
+
+  hpkgs = nixpkgs.haskell.packages."ghc884";
+  # hs = import ./parconc-examples.nix;
+in 
+  hpkgs.shellFor {
+    name = "parconc-examples";
+    packages = _: [];
+    nativeBuildInputs = with hpkgs; [ 
+      stack
+      cabal-install
+      haskell-language-server
+      nixpkgs.pkg-config
+      nixpkgs.zlib
+      parallel
+      implicit-hie
+      threadscope
+  ]; # ++ hs.hackages hpkgs;
+}

--- a/stack.yaml
+++ b/stack.yaml
@@ -1,5 +1,12 @@
-resolver: lts-10.10
+resolver: lts-16.31
 flags:
   parconc-examples:
     distributed: true
     accelerate: true
+
+nix:
+  enable: true
+  shell-file: shell.nix
+  packages: [ zlib.dev, zlib.out, pkg-config ]
+
+


### PR DESCRIPTION
Shell.nix can allow users to build a working environment with haskell-language-server to follow along with the book.